### PR TITLE
style(nftables): unify page title styles across all nftables pages

### DIFF
--- a/frontend/src/views/app/nftables/pages/config/main.vue
+++ b/frontend/src/views/app/nftables/pages/config/main.vue
@@ -5,7 +5,7 @@
 <template>
   <div class="nftables-page-container">
     <div class="header-container">
-      <h2 class="page-title">{{ $t('app.nftables.config.title') }}</h2>
+      <h1 class="page-title">{{ $t('app.nftables.config.title') }}</h1>
 
       <!-- 防火墙状态显示组件 -->
       <firewall-status-header
@@ -245,40 +245,39 @@
 
 <style scoped lang="less">
   .nftables-page-container {
-    padding: 0 16px;
     position: relative;
+    padding: 0 16px;
     background: var(--color-bg-1);
   }
 
   .header-container {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    justify-content: space-between;
     padding: 16px 0;
     margin-bottom: 20px;
   }
 
   .page-title {
-    font-size: 18px;
+    margin: 0;
+    font-size: 1.286rem;
     font-weight: 500;
     color: var(--color-text-1);
-    margin: 0;
   }
 
   /* 响应式设计 */
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     .nftables-page-container {
       padding: 0 12px;
     }
-
     .header-container {
       flex-direction: column;
-      align-items: flex-start;
       gap: 12px;
+      align-items: flex-start;
     }
   }
 
-  @media (max-width: 480px) {
+  @media (width <= 480px) {
     .header-container {
       gap: 8px;
     }

--- a/frontend/src/views/app/nftables/pages/file/main.vue
+++ b/frontend/src/views/app/nftables/pages/file/main.vue
@@ -327,28 +327,25 @@
 
   .page-header {
     display: flex;
-    justify-content: space-between;
+    flex-shrink: 0;
     align-items: flex-start;
+    justify-content: space-between;
     padding: 16px 24px;
     background: var(--color-bg-1);
     border-bottom: 1px solid var(--color-border-2);
-    flex-shrink: 0;
-
     .header-left {
       .page-title {
-        margin: 0 0 4px 0;
-        font-size: 20px;
-        font-weight: 600;
+        margin: 0;
+        font-size: 1.286rem;
+        font-weight: 500;
         color: var(--color-text-1);
       }
-
       .page-subtitle {
-        color: var(--color-text-3);
         font-size: 14px;
         line-height: 1.5;
+        color: var(--color-text-3);
       }
     }
-
     .header-right {
       display: flex;
       align-items: center;
@@ -358,14 +355,13 @@
   .loading-container {
     display: flex;
     flex-direction: column;
+    gap: 16px;
     align-items: center;
     justify-content: center;
     height: 400px;
-    gap: 16px;
-
     .loading-text {
-      color: var(--color-text-2);
       font-size: 14px;
+      color: var(--color-text-2);
     }
   }
 
@@ -375,80 +371,66 @@
 
   .editor-container {
     display: flex;
-    flex-direction: column;
     flex: 1;
-    overflow: hidden;
+    flex-direction: column;
     padding: 16px 24px;
-
+    overflow: hidden;
     .editor-wrapper {
       position: relative;
       flex: 1;
       overflow: hidden;
       border-radius: 8px;
-
       .nftables-editor {
         width: 100%;
         height: 100%;
         min-height: 500px;
-
         :deep(.cm-editor) {
           width: 100%;
           height: 100%;
         }
-
         :deep(.cm-scroller) {
           width: 100%;
           height: 100%;
           overflow: auto;
         }
-
         :deep(.cm-content) {
           min-height: 500px;
         }
       }
-
       .saving-overlay {
         position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
+        inset: 0 0 0 0;
+        z-index: 10;
         display: flex;
         flex-direction: column;
+        gap: 12px;
         align-items: center;
         justify-content: center;
-        background: var(--color-mask-bg, rgba(255, 255, 255, 0.8));
+        background: var(--color-mask-bg, rgb(255 255 255 / 80%));
         backdrop-filter: blur(2px);
-        z-index: 10;
-        gap: 12px;
-
         .saving-text {
-          color: var(--color-text-2);
           font-size: 14px;
+          color: var(--color-text-2);
         }
       }
     }
-
     .editor-footer {
       display: flex;
-      justify-content: space-between;
+      flex-shrink: 0;
       align-items: center;
+      justify-content: space-between;
       padding: 12px 16px;
       margin-top: 16px;
       background: var(--color-bg-2);
       border-radius: 6px;
-      flex-shrink: 0;
-
       .editor-info {
         display: flex;
         align-items: center;
       }
-
       .editor-tips {
         display: flex;
         align-items: center;
       }
-
       .tip-text {
         font-size: 12px;
       }
@@ -456,37 +438,32 @@
   }
 
   // 响应式设计
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     .page-header {
       flex-direction: column;
-      align-items: flex-start;
       gap: 16px;
-
+      align-items: flex-start;
       .header-right {
         align-self: flex-end;
       }
     }
-
     .editor-container .editor-footer {
       flex-direction: column;
-      align-items: flex-start;
       gap: 12px;
-
+      align-items: flex-start;
       .editor-tips {
         align-self: flex-start;
       }
     }
   }
 
-  @media (max-width: 480px) {
+  @media (width <= 480px) {
     .page-header {
       padding: 12px 16px;
-
       .header-left .page-title {
         font-size: 18px;
       }
     }
-
     .editor-container {
       padding: 12px 16px;
     }

--- a/frontend/src/views/app/nftables/pages/ip-blacklist/main.vue
+++ b/frontend/src/views/app/nftables/pages/ip-blacklist/main.vue
@@ -320,53 +320,45 @@
 
 <style scoped lang="less">
   .ip-blacklist-management-page {
-    background: var(--color-bg-1);
     min-height: 100vh;
-
+    background: var(--color-bg-1);
     .page-header {
       padding: 24px;
       border-bottom: 1px solid var(--color-border-2);
-
       .page-title {
-        font-size: 24px;
-        font-weight: 600;
+        margin: 0;
+        font-size: 1.286rem;
+        font-weight: 500;
         color: var(--color-text-1);
-        margin: 0 0 8px 0;
       }
-
       .page-description {
+        margin: 0;
         font-size: 14px;
         color: var(--color-text-3);
-        margin: 0;
       }
     }
-
     .page-content {
       padding: 16px 0;
-
       .loading-container {
-        padding: 60px 24px;
-        min-height: 400px;
         display: flex;
         flex-direction: column;
-        justify-content: center;
         align-items: center;
-
+        justify-content: center;
+        min-height: 400px;
+        padding: 60px 24px;
         .loading-text {
           margin-top: 16px;
           font-size: 14px;
-          color: var(--color-text-3);
           font-weight: 400;
+          color: var(--color-text-3);
         }
       }
-
       .rules-management-container {
-        background: var(--color-bg-2);
-        border-radius: 6px;
         padding: 16px;
         margin: 16px 24px 0;
+        background: var(--color-bg-2);
+        border-radius: 6px;
       }
-
       .error-state {
         margin-top: 40px;
         text-align: center;
@@ -377,39 +369,37 @@
   // 抽屉底部按钮样式
   .drawer-footer {
     display: flex;
-    justify-content: flex-end;
     gap: 12px;
+    justify-content: flex-end;
   }
 
   // 响应式设计
-  @media (max-width: 1024px) {
+  @media (width <= 1024px) {
     .ip-blacklist-management-page {
       .page-header {
-        padding-left: 16px;
         padding-right: 16px;
+        padding-left: 16px;
       }
-
       .page-content {
         .rules-management-container {
-          margin-left: 16px;
           margin-right: 16px;
+          margin-left: 16px;
         }
       }
     }
   }
 
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     .ip-blacklist-management-page {
       .page-header {
-        padding-left: 12px;
         padding-right: 12px;
+        padding-left: 12px;
       }
-
       .page-content {
         .rules-management-container {
-          margin-left: 12px;
-          margin-right: 12px;
           padding: 12px;
+          margin-right: 12px;
+          margin-left: 12px;
         }
       }
     }

--- a/frontend/src/views/app/nftables/pages/ping/main.vue
+++ b/frontend/src/views/app/nftables/pages/ping/main.vue
@@ -215,25 +215,23 @@
 
 <style scoped lang="less">
   .ping-configuration-page {
+    min-height: 100vh;
     padding: 20px;
     background-color: var(--color-bg-1);
-    min-height: 100vh;
   }
 
   .page-header {
     margin-bottom: 24px;
-
     .page-title {
-      font-size: 24px;
-      font-weight: 600;
+      margin: 0;
+      font-size: 1.286rem;
+      font-weight: 500;
       color: var(--color-text-1);
-      margin: 0 0 8px 0;
     }
-
     .page-description {
+      margin: 0;
       font-size: 14px;
       color: var(--color-text-3);
-      margin: 0;
     }
   }
 
@@ -248,11 +246,10 @@
     justify-content: center;
     padding: 60px 20px;
     text-align: center;
-
     .loading-text {
       margin-top: 12px;
-      color: var(--color-text-3);
       font-size: 14px;
+      color: var(--color-text-3);
     }
   }
 
@@ -272,18 +269,16 @@
       flex-direction: column;
       gap: 12px;
     }
-
     .status-indicator {
       :deep(.arco-badge-text) {
         font-size: 16px;
         font-weight: 500;
       }
     }
-
     .status-description {
-      color: var(--color-text-2);
       font-size: 14px;
       line-height: 1.6;
+      color: var(--color-text-2);
     }
   }
 
@@ -291,24 +286,21 @@
     .config-content {
       .form-label-section {
         .form-label {
+          margin-bottom: 4px;
           font-size: 14px;
           font-weight: 500;
           color: var(--color-text-1);
-          margin-bottom: 4px;
         }
-
         .form-description {
-          font-size: 12px;
-          color: var(--color-text-3);
-          line-height: 1.5;
           margin-bottom: 0;
+          font-size: 12px;
+          line-height: 1.5;
+          color: var(--color-text-3);
         }
       }
-
       .switch-wrapper {
         margin-top: 8px;
       }
-
       :deep(.arco-btn) {
         margin-top: 16px;
       }
@@ -316,17 +308,15 @@
   }
 
   // 响应式设计
-  @media (max-width: 768px) {
+  @media (width <= 768px) {
     .ping-configuration-page {
       padding: 16px;
     }
-
     .page-header {
       .page-title {
         font-size: 20px;
       }
     }
-
     .main-content {
       gap: 16px;
     }

--- a/frontend/src/views/app/nftables/pages/ports/main.vue
+++ b/frontend/src/views/app/nftables/pages/ports/main.vue
@@ -387,9 +387,9 @@
       border-bottom: 1px solid var(--color-border-2);
       .header-left {
         .page-title {
-          margin: 0 0 0.571rem 0; // 8px -> rem
-          font-size: 1.714rem; // 24px -> rem
-          font-weight: 600;
+          margin: 0;
+          font-size: 1.286rem;
+          font-weight: 500;
           color: var(--color-text-1);
         }
         .page-description {


### PR DESCRIPTION
## Summary
- 统一 nftables 模块所有页面的标题样式
- 字体大小统一为 `1.286rem`，字重为 `500`，边距为 `0`
- 涉及页面：config、file、ip-blacklist、ping、ports

## Test plan
- [ ] 检查各 nftables 页面标题样式是否一致
- [ ] 确认响应式布局下标题显示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)